### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,8 +12,8 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudUrl": "https://staging.nx.app",
-  "nxCloudId": "681e6e7b36fd5075c64edb8b",
+  "nxCloudUrl": "http://localhost:4202",
+  "nxCloudId": "6826395947d51fcc085b8dc0",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
http://localhost:4202/orgs/6826395247d51fcc085b8dbe/workspaces/6826395947d51fcc085b8dc0

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.